### PR TITLE
Unnest the charMap to avoid undefined references on ldc

### DIFF
--- a/source/httparsed.d
+++ b/source/httparsed.d
@@ -363,7 +363,7 @@ private:
             static if (__VERSION__ >= 2094) pragma(inline, true); // older compilers can't inline this
         } else pragma(inline, true);
 
-        static immutable charMap = buildValidCharMap(ranges);
+        immutable charMap = parseTokenCharMap!(ranges)();
 
         static if (LDC_with_SSE42)
         {
@@ -607,6 +607,11 @@ unittest
             0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
             0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
         ]);
+}
+
+immutable(bool[256]) parseTokenCharMap(string invalidRanges)() {
+    static immutable charMap = buildValidCharMap(invalidRanges);
+    return charMap;
 }
 
 version (unittest) version = WITH_MSG;


### PR DESCRIPTION
This started to show on release builds in s3proxy: https://github.com/skoppe/s3proxy/runs/3141526598?check_suite_focus=true#step:6:45